### PR TITLE
Restart ws when broken pipe err or connection reset by peer

### DIFF
--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/KyberNetwork/deribit-api/pkg/models"
@@ -167,7 +168,18 @@ func (c *Client) Call(ctx context.Context, method string, params interface{}, re
 		params = json.RawMessage("{}")
 	}
 
-	return c.rpcConn.Call(ctx, method, params, result)
+	err = c.rpcConn.Call(ctx, method, params, result)
+	// some case call connection return `broken pipe` or `connection reset by peer`
+	if err != nil && (errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET)) {
+		c.l.Error("failed to call to rpcConn", "err", err)
+		if err := c.conn.Close(); err != nil {
+			c.l.Debugw("failed to close connection", "err", err)
+			// force to restart connection
+			c.restartConnection()
+		}
+	}
+
+	return err
 }
 
 // Handle implements jsonrpc2.Handler
@@ -214,6 +226,7 @@ func (c *Client) heartbeat() {
 				_ = c.conn.Close() // close server
 			}
 		case <-c.heartCancel:
+			l.Debug("cancel heartbeat check")
 			return
 		}
 	}
@@ -227,26 +240,27 @@ func (c *Client) reconnect() {
 			l.Infow("connection will be stopped")
 			return
 		case <-c.rpcConn.DisconnectNotify():
-			c.setIsConnected(false)
+			c.restartConnection()
+		}
+	}
+}
 
-			l.Infow("disconnect, reconnect...")
-
-			close(c.heartCancel)
-
-			time.Sleep(1 * time.Second)
-
-			for {
-				if err := c.Start(); err != nil {
-					if c.rpcConn != nil {
-						_ = c.rpcConn.Close()
-					}
-					l.Errorw("reconnect: start error", "err", err)
-					time.Sleep(5 * time.Second)
-				} else {
-					l.Infow("reconnect successfully")
-					break
-				}
+func (c *Client) restartConnection() {
+	l := c.l.With("func", "restartConnection")
+	c.setIsConnected(false)
+	l.Infow("disconnect, reconnect...")
+	close(c.heartCancel)
+	time.Sleep(1 * time.Second)
+	for {
+		if err := c.Start(); err != nil {
+			if c.rpcConn != nil {
+				_ = c.rpcConn.Close()
 			}
+			l.Errorw("reconnect: start error", "err", err)
+			time.Sleep(5 * time.Second)
+		} else {
+			l.Infow("reconnect successfully")
+			break
 		}
 	}
 }

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -173,9 +173,7 @@ func (c *Client) Call(ctx context.Context, method string, params interface{}, re
 	if err != nil && (errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET)) {
 		c.l.Error("failed to call to rpcConn", "err", err)
 		if err := c.conn.Close(); err != nil {
-			c.l.Debugw("failed to close connection", "err", err)
-			// force to restart connection
-			c.restartConnection()
+			c.l.Warnw("failed to close connection", "err", err)
 		}
 	}
 


### PR DESCRIPTION
Sometimes the connection to web socket Deribit is lost, and we receive the `broken pipe` or `connection reset by peer` error, we need to:
- [x] Check the err when doing jsonrpc call, if `broken pipe` or `connection reset by peer` error appears, restart web socket connection
